### PR TITLE
update init.py to fetch the right task id

### DIFF
--- a/eeUtil/__init__.py
+++ b/eeUtil/__init__.py
@@ -277,9 +277,9 @@ def ingestAsset(gs_uri, asset, date='', wait_timeout=0, bands=[]):
     task_id = ee.data.newTaskId()[0]
     logging.debug('Ingesting {} to {}: {}'.format(gs_uri, asset, task_id))
     logging.info(f'Ingestion params: {params}')
-    ee.data.startIngestion(task_id, params, True)
+    task = ee.data.startIngestion(task_id, params, True)
     if wait_timeout:
-        waitForTask(task_id, wait_timeout)
+        waitForTask(task['id'], wait_timeout)
     return task_id
 
 


### PR DESCRIPTION
the code used to create a task id, started the task with the id, and tracked the status of the task based on this id; however, the task id actually changes after ingestion started, so I updated the code to fetch the updated task id and check the task status based on that 